### PR TITLE
loofahを2.2.3にupdate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
railsが依存しているloofahというライブラリにXSS脆弱性があるという警告が出てたので，docker-compose run web bundle update loofahを実行，updateされて，Gemfile.lockも更新されました