### PR TITLE
Edit show2

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     else
       # エラーメッセージを作成する
       flash.now[:danger] = 'eメールまたはパスワードが違います。'
-      render 'new'
+      render 'new' , :layout => nil
     end
   end
 

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -58,7 +58,7 @@
         <div id="inputText">
           <textarea
             @keyup.ctrl.enter="transmissionMessage"
-            @keyup.ctrl.delete="skipQuestion"
+            @keyup.ctrl.space="skipQuestion"
             v-model="answer"
             placeholder="解答を入力"
             style="width:100%;height:100%;"

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -224,6 +224,21 @@ export default {
         simplemde = new SimpleMDE({
           element: document.getElementById("MyID"),
           initialValue: that.note,
+          toolbar: [
+            "bold",
+            "italic",
+            "heading",
+            "|",
+            "quote",
+            "unordered-list",
+            "ordered-list",
+            "|",
+            "link",
+            "image",
+            "|",
+            "preview",
+            "guide"
+          ],
           forceSync: true, //エディタの入力値をdocument.getElementById("MyID").valueで取得できるようになる
           autofocus: true //エディタに自動フォーカスする
         });

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,30 +1,34 @@
 <div class="container">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="card-deck">
-                <% @documents.each do |document| %>
-                <div class="col-md-3">
-                    <div class="card">
-                        <%= image_tag 'note_image', :size =>'150x150', :class => 'card-img-top' %>
-                        <div class="card-body">
-                            <h5 class="card-title">
-                                <p>
-                                    <%= link_to document.title ,document, data: {"turbolinks" => false}%>
-                                </p>
-                                <p style="font-size:4px;">アシスタント</p>
-                                <p style="font-size:4px;">・
-                                    <%= document.template.title %>
-                                </p>
-                            </h5>
-                            <%= link_to "削除" ,document, method: :delete, data: { confirm: "本当にこのノートを削除しますか?" } %>
-                        </div>
-                    </div>
-                </div>
-                <% end %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="card-deck">
+        <% @documents.each do |document| %>
+        <div class="col-md-3">
+          <div class="card img-thumbnail">
+            <%if document.template.picture?%>
+              <%= image_tag document.template.picture , :class => 'ass-pic card-img-top'%>
+            <%else%>
+              <%= image_tag 'hakohugu 200X200.png', :class => 'ass-pic card-img-top'%>
+            <%end%>
+            <div class="card-body px-2 py-3 border-top">
+              <h5 class="card-title">
+                <p>
+                  <%= link_to document.title ,document, data: {"turbolinks" => false}%>
+                </p>
+                <p style="font-size:4px;">アシスタント</p>
+                <p style="font-size:4px;">・
+                  <%= document.template.title %>
+                </p>
+              </h5>
+              <%= link_to "削除" ,document, method: :delete, data: { confirm: "本当にこのノートを削除しますか?" } %>
             </div>
-            <div style="padding-top: 160px;">
-                <%= link_to "+", new_document_path, class: 'btn btn-success rounded-circle p-0 float-right',style: 'width:6rem;height:6rem; font-size:3.5rem;' %>
-            </div>
+          </div>
         </div>
+        <% end %>
+      </div>
+      <div style="padding-top: 160px;">
+        <%= link_to "+", new_document_path, class: 'btn btn-success rounded-circle p-0 float-right',style: 'width:6rem;height:6rem; font-size:3.5rem;' %>
+      </div>
     </div>
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,11 +12,11 @@
 
   <body>
     <%= render 'layouts/header' %>
-    <div class="container" id="hakohugu">
+    <div id="hakohugu">
      <% flash.each do |message_type, message| %>
         <div class="alert alert-<%= message_type %>"><%= message %></div>
      <% end %>
+     <%= yield %>
     </div>
-    <%= yield %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,44 +1,57 @@
 <!DOCTYPE html>
-<html lang="ja">
-  <head>
-    <title>Cogito</title>
-    <meta charset="utf-8">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-  </head>
- <body>
-<div class = "back">
-<div class="container-fulid">
-<div class="jodan_block">
-	<br>
-	<%= image_tag('hakohugu.png',:class => "hugu") %>
-	
-	<%= image_tag('title.png',:class => "title") %><br><br><br>
-	<%= image_tag('steps.png' ,:class => "step") %>
-	<br><br>
-</div>
-<div class = "gedan_block">
-	<br><br>
-<%= form_for(:session, url: login_path) do |f| %>
-			<div class="form-group">
-			  <%= f.label :eメール %>
-			  <%= f.email_field :email , class: 'form-control ' %>
-			</div>
-			<div class="form-group">
-				 <%= f.label :password %>
-				 <%= f.password_field :password , class: 'form-control ' %>
-			</div>
-			<div class="form-group">
-			  <%= f.submit "ログイン", class: "btn btn-primary" %>
-			</div>
-		 
-  <% end %>
 
-    <p>アカウントの新規作成は <%= link_to "こちら", new_user_path %></p>
-</div>
-</div>
-</div>
+<head>
+	<title>Cogito</title>
+	<meta charset="utf-8">
+	<%= csrf_meta_tags %>
+	<%= csp_meta_tag %>
+	<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+	<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+</head>
+
+<body>
+	<div class="back">
+		<div class="container-fulid">
+			<div class="jodan_block">
+				<br>
+				<%= image_tag('hakohugu.png',:class => "hugu") %>
+
+				<%= image_tag('title.png',:class => "title") %><br><br><br>
+				<%= image_tag('steps.png' ,:class => "step") %>
+				<br><br>
+			</div>
+
+			<div>
+				<% flash.each do |message_type, message| %>
+				<div class="alert alert-<%= message_type %>">
+					<%= message %>
+				</div>
+				<% end %>
+			</div>
+
+			<div class="gedan_block">
+				<br><br>
+				<%= form_for(:session, url: login_path) do |f| %>
+				<div class="form-group">
+					<%= f.label :eメール %>
+					<%= f.email_field :email , class: 'form-control ' %>
+				</div>
+				<div class="form-group">
+					<%= f.label :password %>
+					<%= f.password_field :password , class: 'form-control ' %>
+				</div>
+				<div class="form-group">
+					<%= f.submit "ログイン", class: "btn btn-primary" %>
+				</div>
+
+				<% end %>
+
+				<p>アカウントの新規作成は
+					<%= link_to "こちら", new_user_path %>
+				</p>
+			</div>
+		</div>
+	</div>
 </body>
+
 </html>

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -1,68 +1,91 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <h2>すべてのアシスタント</h2>
+      <h2 class="mb-4">すべてのアシスタント</h2>
+
 
       <!-- 検索 -->
-      <%= form_tag(templates_path, :method => 'get') do %>
-      <%= text_field_tag :search %>
-      <%= submit_tag '検索', :name => nil %>
-    <% end %>
-  </br>
-
-  <div class="card-deck">
-    <% @templates.each do |template| %>
-      <div class="col-md-3">
-        <div class="card">
-          <%= image_tag 'note_image', :size =>'150x150', :class => 'card-img-top' %>
-          <div class="card-body">
-            <h5 class="card-title">
-              <%= link_to template.title ,template_path(template.id), data: {"turbolinks" => false}%>
-            </h5>
+      <div class='mb-4'>
+        <%= form_tag(templates_path, :method => 'get') do %>
+        <div class="form-row">
+          <div class="col">
+            <%= text_field_tag :search ,'',:class => 'form-control',:placeholder =>'アシスタントを検索' %>
+          </div>
+          <div class="col">
+          <%= button_tag '検索', class: 'btn btn-primary' %>
           </div>
         </div>
+        <% end %>
       </div>
-    <% end %>
+
+      <div class="card-deck">
+        <% @templates.each do |template| %>
+        <div class="col-md-3">
+          <div class="card img-thumbnail">
+            <%if template.picture?%>
+              <%= image_tag template.picture, :class => 'ass-pic card-img-top'%>
+            <%else%>
+              <%= image_tag 'hakohugu 200X200.png', :class => 'ass-pic card-img-top'%>
+            <%end%>
+            <div class="card-body px-2 py-3 border-top">
+              <h5 class="card-title">
+                <%= link_to template.title ,template_path(template.id), data: {"turbolinks" => false}%>
+              </h5>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </div>
+
+      </br>
+
+      <%= will_paginate(:renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer) %>
+      </br>
+
+      <h2>マイアシスタント</h2>
+      <div class="my_unreleased">
+        <h3>未公開</h3>
+        <div class="card-deck">
+          <% @my_templates_unreleased.each do |template_u| %>
+          <div class="col-md-3">
+            <div class="card img-thumbnail">
+              <%if template_u.picture?%>
+              <%= image_tag template_u.picture , :class => 'ass-pic card-img-top'%>
+              <%else%>
+              <%= image_tag 'hakohugu 200X200.png', :class => 'ass-pic card-img-top'%>
+              <%end%>
+              <div class="card-body px-2 py-3 border-top">
+                <h5 class="card-title">
+                  <%= link_to template_u.title ,template_path(template_u.id), data: {"turbolinks" => false}%>
+                </h5>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="my_released">
+        <h3>公開済</h3>
+        <div class="card-deck">
+          <% @my_templates_released.each do |template| %>
+          <div class="col-md-3">
+            <div class="card img-thumbnail">
+              <%if template.picture?%>
+              <%= image_tag template.picture , :class => 'ass-pic card-img-top'%>
+              <%else%>
+              <%= image_tag 'hakohugu 200X200.png', :class => 'ass-pic card-img-top'%>
+              <%end%>
+              <div class="card-body px-2 py-3 border-top">
+                <h5 class="card-title">
+                  <%= link_to template.title ,template_path(template.id), data: {"turbolinks" => false}%>
+                </h5>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
-</br>
-<%= will_paginate(:renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer) %>
-</br>
-<h2>マイアシスタント</h2>
-<div class="my_unreleased">
-<h3>未公開</h3>
-<div class="card-deck">
-  <% @my_templates_unreleased.each do |template_u| %>
-    <div class="col-md-3">
-      <div class="card">
-        <%= image_tag 'note_image', :size =>'150x150', :class => 'card-img-top' %>
-        <div class="card-body">
-          <h5 class="card-title">
-            <%= link_to template_u.title ,template_path(template_u.id), data: {"turbolinks" => false}%>
-          </h5>
-        </div>
-      </div>
-    </div>
-  <% end %>
-</div>
-</div>
-
-<div class="my_released">
-<h3>公開済</h3>
-<div class="card-deck">
-  <% @my_templates_released.each do |template| %>
-    <div class="col-md-3">
-      <div class="card">
-        <%= image_tag 'note_image', :size =>'150x150', :class => 'card-img-top' %>
-        <div class="card-body">
-          <h5 class="card-title">
-            <%= link_to template.title ,template_path(template.id), data: {"turbolinks" => false}%>
-          </h5>
-        </div>
-      </div>
-    </div>
-  <% end %>
-</div>
-
-</div>
-</div>
 </div>

--- a/app/views/templates/show.html.erb
+++ b/app/views/templates/show.html.erb
@@ -1,63 +1,81 @@
-<div class="container">
-  <div class="starter-template">
-    <h1><%= @template.title%></h1>
-  </br>
+<div class="starter-template">
+  <div class = 'mb-5'>
+    <h1 class='mb-5'>
+      <%= @template.title%>
+    </h1>
+    <span class='h5'>
+      <span class = 'font-weight-bold'> トピック:</span><span class='mr-3'><%= @template.topic%></span>
+      <span class = 'font-weight-bold ml-3'>カテゴリ: </span><span><%= @category.name%></span>
+    </span>
+  </div>
 
-  <% if @template.scope == 0 %>
-    <h2><%= link_to "編集", edit_template_path(@template.id)%></h2>
-    <h2><%= link_to "削除", @template, method: :delete,data: { confirm: "本当にこのアシスタントを削除しますか?" } %></h2>
-    <% if @questions.present? %>
-      <h2><%= link_to "公開する", release_template_path(@template.id), data:{confirm: "本当にこのアシスタントを公開しますか？\n一度公開されると戻せません。"}%></h2>
-    <% else %>
-      <div class="alert alert-warning" role="alert">
-        質問が一つ以上ないとこのアシスタントは公開できません
-      </div>
-    <%end%>
-  <% end %>
+  <div>
+    <% if @template.scope == 0 %>
+      <span class='h1 mt-5'>
+        <%= link_to "編集", edit_template_path(@template.id)%>     
+        <%= link_to "削除", @template, method: :delete,data: { confirm: "本当にこのアシスタントを削除しますか?" } %>
+      </span>
 
-  <% if @template.scope == 1 %>
-    <%= form_for(@document) do |f| %>
-    <div class="form-group">
-      <%= f.label :ノートタイトル %>
-      <%= f.text_field :title, class: 'form-control' %>
-    </div>
+      <% if @questions.present? %>
+        <p class='h1 mt-5'>
+          <%= link_to "公開する", release_template_path(@template.id), data:{confirm: "本当にこのアシスタントを公開しますか？\n一度公開されると戻せません。"}%>
+        </p>
+      <% else %>
+        <div class="alert alert-warning" role="alert">
+          質問が一つ以上ないとこのアシスタントは公開できません
+        </div>
+      <% end %>
 
-    <div class="form-group">
-      <%= f.hidden_field :template_id, :value => @template.id %>
-    </div>
+    <% elsif @template.scope == 1 %>
+      <%= form_for(@document) do |f| %>
+        <div class="form-group">
+            <%= f.label :ノートタイトル %>
+            <%= f.text_field :title, class: 'form-control w-50 mx-auto', value:'無題'  %>
+        </div>
+           
+        <%= f.hidden_field :template_id, :value => @template.id %>
 
-    <%= f.submit "このアシスタントとトークを開始", class: "btn btn-primary" %>
-  <% end %>
+        <div class="form-group">
+          <%= f.submit "このアシスタントとトークを開始", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
 
-<% end %>
-
-</div>
-<h3>トピック</h3>
-<p>
-<%= @template.topic%>
-</p>
-</br>
-<h3>カテゴリ</h3>
-<p>
-<%= @category.name%>
-</p>
-</br>
-<% @questions.each do |question|%>
-<h3><%= "質問"%></h3>
-</br>
-<p>
-<%= question.qtext%>
-</p>
-</br>
-<p>
-質問の詳細：<%=question.qdetail%>
-</p>
-</br>
-<p>
-回答例：<%=question.example%>
-</p>
-</br>
-
-<% end %>
-
+  <div class='mt-5'>
+    <table class="table table-striped table-hover">
+      <thead>
+        <tr>
+          <th> </th>
+          <th scope="col">質問名</th>
+          <th scope="col">質問の詳細</th>
+          <th scope="col">回答例</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% count = 1 %>
+        <% @questions.each do |question|%>
+        <tr>
+          <th>質問
+            <%= count %>
+          </th>
+          <td>
+            <%= question.qtext%>
+          </td>
+        
+          <td>
+            質問の詳細：
+            <%=question.qdetail%>
+          </td>
+        
+          <td>
+            回答例：
+            <%=question.example%>
+          </td>
+        </tr>
+        <% count += 1 %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
アシスタントの詳細ページのレイアウトを変更、タイトルのデフォルトを無題に
<img width="1440" alt="2018-12-30 10 02 46" src="https://user-images.githubusercontent.com/38548489/50543369-1f943380-0c1a-11e9-8310-535acd8f8fb6.png">
ログイン失敗時のCSSのズレを修正
ノート、アシスタントの一覧の画像をデータベースの画像に変更、ない場合はハコフグ
<img width="1438" alt="2018-12-30 10 04 29" src="https://user-images.githubusercontent.com/38548489/50543377-59fdd080-0c1a-11e9-85f6-4f0935d2e000.png">
ctrl+spaceでスキップ、ctrl+Enterで解答の送信のショートカットキーを追加
simplemdeのバグが起こるボタンを除去
