### PR TITLE
アシスタントの返答時に、一時的にローディング表示処理を挟む処理を実装

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -348,9 +348,14 @@ export default {
         } else {
           this.tutorial_flag = false;
           this.help_flag = false;
+          //遅延処理
           this.conversationLogs.push({
-            question: this.questions[this.count].qtext
+           question: "..."
           });
+          setTimeout(()=>{this.conversationLogs.pop();},500);
+          setTimeout(()=>{this.conversationLogs.push({
+              question: this.questions[this.count].qtext
+          });},500);
         }
       }
 
@@ -408,9 +413,14 @@ export default {
       }
 
       if (this.questions[this.count]) {
-        this.conversationLogs.push({
-          question: this.questions[this.count].qtext
-        });
+       //遅延処理
+          this.conversationLogs.push({
+           question: "..."
+          });
+          setTimeout(()=>{this.conversationLogs.pop();},500);
+          setTimeout(()=>{this.conversationLogs.push({
+              question: this.questions[this.count].qtext
+          });},500);
       }
 
       if (this.questions.length == this.count) {


### PR DESCRIPTION
回答ボタンを押したあと、

アシスタント側に思考中を表す「...」が吹き出しに一定時間表示
↓
次の質問を吹き出しに表示

のように動作します。