### PR TITLE
ナビバーのすぐ下の余白とページ下の余白を挿入

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,8 @@
 
 #hakohugu {
     font-size: .875rem;
-    padding-top:80px;
+    padding-top:120px;
+    padding-bottom:40px; //ページ下余白
 }
 
 .starter-template {


### PR DESCRIPTION
ナビバーの下の余白と、ページ下部の余白を増やして余裕をもたせました。
(最終スプリントで指摘された箇所)
変更はCSSを2行ほど修正した程度です。
変更後↓
<ページ上部>
![image](https://user-images.githubusercontent.com/38551932/50957958-e48bdd00-1502-11e9-9579-361deff835e4.png)

 
<ページ下部>
![image](https://user-images.githubusercontent.com/38551932/50957978-efdf0880-1502-11e9-92cc-5d0b8589a628.png)
