### PR TITLE
トップページ下の余白のバグの修正と、各ページの余白の調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,13 @@
 
 #hakohugu {
     font-size: .875rem;
-    padding-top:80px;
+    padding-top:120px;
+    padding-bottom:40px;
+}
+
+body {
+  height: 100%;
+  margin: 0;
 }
 
 .starter-template {

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -2,7 +2,10 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.back{ background-color: #ABD8DA;}
+.back{
+	height: 100%;
+	background-color: #ABD8DA;
+}
 .container-fulid{
 	width:100%
 }


### PR DESCRIPTION
ページの余白について以下の修正をしました。
・トップページ下に意図せぬ余白が表示されるバグを修正しました。
・ナビバーの下とページ下部(回答ボタンの下)に適当な余白を追加し、操作しやすくしました。

<トップページ>
![image](https://user-images.githubusercontent.com/38551932/50965443-4ce3ba00-1515-11e9-982c-ec0633fb7377.png)
↓修正
![image](https://user-images.githubusercontent.com/38551932/50965492-6e44a600-1515-11e9-9338-38175de395d0.png)

<ナビバー下(修正後)>
![image](https://user-images.githubusercontent.com/38551932/50965590-bbc11300-1515-11e9-86df-c2cb50e9310a.png)


<回答ボタン下(修正後)>
![image](https://user-images.githubusercontent.com/38551932/50965601-c380b780-1515-11e9-8d74-8e2d0d0f5e05.png)

