### PR TITLE
質問の表示順序を制御

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -5,7 +5,7 @@ class Api::QuestionsController < ApplicationController
      @document = Document.find(document_id)
      template_id = @document.template_id
      @template = Template.find(template_id)
-     @questions = @template.questions
+     @questions = @template.questions.order(:id)
      @template.picture? ? @image_path1 = view_context.cl_image_path(@template.picture) : @image_path1 = view_context.image_path('hakohugu 200X200.png')
      @user = @document.user
      @user.picture? ? @image_path2 = view_context.cl_image_path(@user.picture) : @image_path2 = view_context.image_path('hakohugu2 200X200.png')

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -33,7 +33,7 @@ class TemplatesController < ApplicationController
   def show
     @template=Template.find(params[:id])
     @category=Category.find(@template.category_id)
-    @questions=Question.where(template_id: @template.id)
+    @questions=Question.where(template_id: @template.id).order(:id)
     @document = Document.new
   end
 
@@ -68,7 +68,7 @@ class TemplatesController < ApplicationController
   def update
     @template=Template.find(params[:id])
     @category=Category.find(@template.category_id)
-    @questions=Question.where(template_id: @template.id)
+    @questions=Question.where(template_id: @template.id).order(:id)
     @document=Document.new
     if @category.update_attributes(category_params)
       if @template.update_attributes(template_params)

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -62,6 +62,7 @@ class TemplatesController < ApplicationController
   def edit
     @template=Template.find(params[:id])
     @category=Category.find(@template.category.id)
+	@questions=Question.where(template_id: @template.id).order(:id)
     @submit='更新'
   end
 

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -27,13 +27,14 @@ class TemplatesController < ApplicationController
 
   def new
     @template=Template.new
+	@template.questions.build
     @category=Category.new
   end
 
   def show
     @template=Template.find(params[:id])
     @category=Category.find(@template.category_id)
-    @questions=Question.where(template_id: @template.id).order(:id)
+    @questions=@template.questions.order(:id)
     @document = Document.new
   end
 
@@ -62,14 +63,14 @@ class TemplatesController < ApplicationController
   def edit
     @template=Template.find(params[:id])
     @category=Category.find(@template.category.id)
-	@questions=Question.where(template_id: @template.id).order(:id)
+	@questions=@template.questions.order(:id)
     @submit='更新'
   end
 
   def update
     @template=Template.find(params[:id])
     @category=Category.find(@template.category_id)
-    @questions=Question.where(template_id: @template.id).order(:id)
+    @questions=@template.questions.order(:id)
     @document=Document.new
     if @category.update_attributes(category_params)
       if @template.update_attributes(template_params)
@@ -118,6 +119,10 @@ class TemplatesController < ApplicationController
 
     def template_params
         params.require(:template).permit(:title,:topic,:category_id,:picture,questions_attributes: [:id, :qtext, :qdetail, :example, :_destroy]).merge(user_id: current_user.id)
+    end
+	
+	def question_params
+        params.require(:question).permit(:qtext, :qdetail, :example)
     end
 
     def category_params

--- a/app/views/api/questions/show.json.jbuilder
+++ b/app/views/api/questions/show.json.jbuilder
@@ -1,6 +1,6 @@
 # coding: utf-8
 json.questions do
-   json.array! @questions, :qtext,:qdetail,:example 
+   json.array! @questions.order(:id), :qtext,:qdetail,:example 
 end
 json.title @document.title
 json.content @document.content

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -45,12 +45,13 @@
 
 <h3>質問</h3>
 <div id="questions">
-  <%= f.fields_for :questions do |question| %>
-  <%= render 'question_fields', f: question %>
-<% end %>
-<div class="links">
-  <%= link_to_add_association '+質問を追加', f, :questions, class: 'btn btn-light mb-5'%>
-</div>
+
+    <%= render 'question_fields', object:@question %>
+  
+ 
+  <div class="links">
+    <%= link_to_add_association '+質問を追加', f, :questions, class: 'btn btn-light mb-5'%>
+  </div>
 </div>
 
 <div class="actions">

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -45,13 +45,12 @@
 
 <h3>質問</h3>
 <div id="questions">
-
-    <%= render 'question_fields', object:@question %>
-  
- 
-  <div class="links">
-    <%= link_to_add_association '+質問を追加', f, :questions, class: 'btn btn-light mb-5'%>
-  </div>
+  <%= f.fields_for :questions, @questions do |question| %>
+  <%= render 'question_fields', f: question %>
+<% end %>
+<div class="links">
+  <%= link_to_add_association '+質問を追加', f, :questions, class: 'btn btn-light mb-5'%>
+</div>
 </div>
 
 <div class="actions">

--- a/app/views/templates/_question_fields.html.erb
+++ b/app/views/templates/_question_fields.html.erb
@@ -1,16 +1,14 @@
-<%= fields_for (@question) do |i| %>
-  <div class="nested-fields">
-    <div class="form-group">
-      <%= i.label :qtext, "質問" ,class: 'font-weight-bold' %>
-      <%= i.text_field :qtext, class: 'form-control' %>
-      <br/>
-      <%= i.label :qdetail, "質問の意図や意味" ,class: 'font-weight-bold'%>
-      <%= i.text_field :qdetail, class: 'form-control' %>
-      <br/>
-      <%= i.label :example, "回答例" ,class: 'font-weight-bold'%>
-      <%= i.text_field :example, class: 'form-control' %>
-      <br/>
-    </div>
-    <%= link_to_remove_association "この質問を削除", i ,class: 'btn btn-danger mb-5'%>
+<div class="nested-fields">
+  <div class="form-group">
+    <%= f.label :qtext, "質問" ,class: 'font-weight-bold' %>
+    <%= f.text_field :qtext, class: 'form-control' %>
+    <br/>
+    <%= f.label :qdetail, "質問の意図や意味" ,class: 'font-weight-bold'%>
+    <%= f.text_field :qdetail, class: 'form-control' %>
+    <br/>
+    <%= f.label :example, "回答例" ,class: 'font-weight-bold'%>
+    <%= f.text_field :example, class: 'form-control' %>
+    <br/>
   </div>
- <% end %>
+  <%= link_to_remove_association "この質問を削除", f ,class: 'btn btn-danger mb-5'%>
+</div>

--- a/app/views/templates/_question_fields.html.erb
+++ b/app/views/templates/_question_fields.html.erb
@@ -1,14 +1,16 @@
-<div class="nested-fields">
-  <div class="form-group">
-    <%= f.label :qtext, "質問" ,class: 'font-weight-bold' %>
-    <%= f.text_field :qtext, class: 'form-control' %>
-    <br/>
-    <%= f.label :qdetail, "質問の意図や意味" ,class: 'font-weight-bold'%>
-    <%= f.text_field :qdetail, class: 'form-control' %>
-    <br/>
-    <%= f.label :example, "回答例" ,class: 'font-weight-bold'%>
-    <%= f.text_field :example, class: 'form-control' %>
-    <br/>
+<%= fields_for (@question) do |i| %>
+  <div class="nested-fields">
+    <div class="form-group">
+      <%= i.label :qtext, "質問" ,class: 'font-weight-bold' %>
+      <%= i.text_field :qtext, class: 'form-control' %>
+      <br/>
+      <%= i.label :qdetail, "質問の意図や意味" ,class: 'font-weight-bold'%>
+      <%= i.text_field :qdetail, class: 'form-control' %>
+      <br/>
+      <%= i.label :example, "回答例" ,class: 'font-weight-bold'%>
+      <%= i.text_field :example, class: 'form-control' %>
+      <br/>
+    </div>
+    <%= link_to_remove_association "この質問を削除", i ,class: 'btn btn-danger mb-5'%>
   </div>
-  <%= link_to_remove_association "この質問を削除", f ,class: 'btn btn-danger mb-5'%>
-</div>
+ <% end %>

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -47,9 +47,9 @@
             <div class="card">
               <%if template.picture?%>
 			    <%if Rails.env.production?%>
-                  <%= cl_image_tag(template.picture)%>
+                  <%= cl_image_tag(template.picture,:class => 'card-img-top')%>
 			    <%else%>
-			      <%= image_tag template.picture.url %>
+			      <%= image_tag template.picture.url,:class => 'card-img-top' %>
 			    <%end%>
               <%else%>
                 <%= image_tag 'hakohugu 200X200.png', :class => 'card-img-top'%>


### PR DESCRIPTION
編集画面でなんとか順序を変えたかったのだけど、fields_forの指定先がシンボル（なのか？）になってることでorderやsortが使えず、categoryと同じくインスタンスを渡す方向で行こうとした結果、もともと_formでブロック回して毎度renderしてたところを、renderを一回だけにして_question_fieldの中でブロックを使っています。それで今、_question_field中のlink_to_remove_associationでエラーがでる状態です。
※今回の順序のエラーはデプロイ環境だけでの話だけど、ローカルで任意に順番を動かせる（逆順にしても反映されることが確認できる）ならデプロイでも成功すると思います。template/show等はorder指定しただけで直ったので。