### PR TITLE
みんなのノートのページで アシスタントを検索するときに 検索ボタンを押すと、新規作成アシスタント作成のページに飛んじゃうバグの修正 + 検索候補表示の追加 #198

### DIFF
--- a/app/views/documents/open.html.erb
+++ b/app/views/documents/open.html.erb
@@ -7,13 +7,13 @@
 
       <!-- 検索 -->
       <div class='mb-4'>
-        <%= form_tag(templates_path, :method => 'get') do %>
+        <%= form_tag(documents_open_path, :method => 'get') do %>
           <div class="form-row">
             <div>
-              <%= select_tag :select, options_for_select([["タイトル", 'title'], ["カテゴリ", 'category']]) , class:"custom-select" %>
+              <%= select_tag :select, options_for_select([["タイトル", 'title'], ["カテゴリ", 'category']]) , class:"custom-select", id:"select_key"%>
             </div>
             <div class="col">
-              <%= text_field_tag :search ,'',:class => 'form-control',:placeholder =>'アシスタントを検索' %>
+              <%= text_field_tag :search ,'',:class => 'form-control',:placeholder =>'アシスタントを検索' ,:id=>'template_or_category_name'%>
             </div>
             <div class="col">
               <%= button_tag '検索', class: 'btn btn-primary' %>
@@ -60,3 +60,44 @@
     </div>
   </div>
 </div>
+
+<script>
+$(function() {
+  $( "#template_or_category_name" ).autocomplete({
+    autoFocus: true,
+     source: "/templates/template_auto_complete.json",
+      minLength: 1,
+    messages: {
+      noResults: '',
+      results: function() {}
+    }
+  });
+
+  var key; 
+  $("#select_key").on("change",function(){
+    key = this.value;
+      if(key == 'title'){
+        $( "#template_or_category_name" ).autocomplete({
+          autoFocus: true,
+          source: "/templates/template_auto_complete.json",
+            minLength: 1,
+          messages: {
+            noResults: '',
+            results: function() {}
+          }
+        });
+      }
+      else{
+        $( "#template_or_category_name" ).autocomplete({
+        autoFocus: true,
+        source: "/templates/category_auto_complete.json",
+          minLength: 1,
+        messages: {
+          noResults: '',
+          results: function() {}
+        }
+      });
+      }
+  });
+});
+</script>


### PR DESCRIPTION
みんなのノートのページで アシスタントを検索するときに 検索ボタンを押すと、新規作成アシスタント作成のページに飛んじゃうバグの修正 + 検索候補表示の追加 #198