### PR TITLE
#200 & 不要な+ボタンの除去 + documents関係を見るときは、全てログイン必須に

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,5 +1,5 @@
 class DocumentsController < ApplicationController
-  before_action :logged_in_user, only: [:index,:new, :update,:show]
+  before_action :logged_in_user
   before_action :correct_user,   only: [:show]
   protect_from_forgery except: :test
   
@@ -87,9 +87,13 @@ class DocumentsController < ApplicationController
 
   def read
     @document = Document.find(params[:id])
-    @template = Template.find(@document.template_id)
-    @category=Category.find(@template.category_id)
-    @questions=Question.where(template_id: @template.id)
+    if @document.scope == 0
+      redirect_to documents_open_path
+    else
+      @template = Template.find(@document.template_id)
+      @category=Category.find(@template.category_id)
+      @questions=Question.where(template_id: @template.id)
+    end
   end
 
 

--- a/app/views/documents/assistant.html.erb
+++ b/app/views/documents/assistant.html.erb
@@ -1,44 +1,48 @@
 <div class="container">
   <div class="row">
-  <h2>「<%= link_to @template.title,template_path(@template.id),data: {"turbolinks" => false}%>」を使ったみんなのノート</h2>
+    <h2>「<%= link_to @template.title,template_path(@template.id),data: {"turbolinks" => false}%>」を使ったみんなのノート</h2>
     <div class="col-md-12">
-      <div class="card-deck">
-        <% @documents.each do |document| %>
-        <div class="col-md-3">
-          <div class="card img-thumbnail">
-            <%if document.template.picture?%>
-			  <%if Rails.env.production?%>
-                <%= cl_image_tag(document.template.picture,:class => 'ass-pic')%>
-			  <%else%>
-				<%= image_tag document.template.picture.url,:class => 'ass-pic'%>
-			  <%end%>
-            <%else%>
-              <%= image_tag 'hakohugu 200X200.png', :class => 'ass-pic'%>
-            <%end%>
-            <div class="card-body px-2 py-3 border-top">
-              <h5 class="card-title">
-                <p>
-                  <%= link_to document.title,read_document_path(document.id), data: {"turbolinks" => false}%>
-                </p>
-                <p style="font-size:5%;">アシスタント</p>
-                <p style="font-size:5%;">・
-                  <%= document.template.title %>
-                </p>
-              </h5>
-              <% if document.user_id == @user.id %>
-              <%= link_to "削除" ,document, method: :delete, data: { confirm: "本当にこのノートを削除しますか?" } %><br>
-              <% if document.scope == 1%>
-              <%= link_to "非公開にする", release_document_path(document.id), data:{confirm: "このノートを非公開にします"}%>
-              <% end %>
-              <% end %>
+      <%if @documtnts %>
+        <div class="card-deck">
+          <% @documents.each do |document| %>
+          <div class="col-md-3">
+            <div class="card img-thumbnail">
+              <%if document.template.picture?%>
+                <%if Rails.env.production?%>
+                  <%= cl_image_tag(document.template.picture,:class => 'ass-pic')%>
+                <%else%>
+                  <%= image_tag document.template.picture.url,:class => 'ass-pic'%>
+                <%end%>
+              <%else%>
+                <%= image_tag 'hakohugu 200X200.png', :class => 'ass-pic'%>
+              <%end%>
+              <div class="card-body px-2 py-3 border-top">
+                <h5 class="card-title">
+                  <p>
+                    <%= link_to document.title,read_document_path(document.id), data: {"turbolinks" => false}%>
+                  </p>
+                  <p style="font-size:5%;">アシスタント</p>
+                  <p style="font-size:5%;">・
+                    <%= document.template.title %>
+                  </p>
+                </h5>
+                <% if document.user_id == @user.id %>
+                  <%= link_to "削除" ,document, method: :delete, data: { confirm: "本当にこのノートを削除しますか?" } %><br>
+                  <% if document.scope == 1%>
+                    <%= link_to "非公開にする", release_document_path(document.id), data:{confirm: "このノートを非公開にします"}%>
+                  <% end %>
+                <% end %>
+              </div>
             </div>
           </div>
+          <% end %>
+        
+        
+        
         </div>
-        <% end %>
-      </div>
-      <div style="padding-top: 160px;">
-        <%= link_to "+", new_document_path, class: 'btn btn-success rounded-circle p-0 float-right',style: 'width:6rem;height:6rem; font-size:3.5rem;' %>
-      </div>
+      <%else%>
+        <p class='mt-3' style="font-size:20px;">このアシスタントを使った公開中のノートはありません</p>
+      <%end%>
     </div>
   </div>
 </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -98,11 +98,6 @@
         </div>
         <% end %>
       </div>
-
-      <div style="padding-top: 160px;">
-        <%= link_to "+", new_document_path, class: 'btn btn-success rounded-circle p-0 float-right',style: 'width:6rem;height:6rem; font-size:3.5rem;' %>
-      </div>
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
公開にしていないノートが、
documents/[ノートのid]/read
のurlを入れると、どのユーザーからでもノートが見えてしまう致命的なバグを直しました。

不要な+ボタンの除去をしました。

documents関係を見るときは、全てログイン必須にしました。
